### PR TITLE
Fixed UB on OS X

### DIFF
--- a/graphics.hpp
+++ b/graphics.hpp
@@ -61,7 +61,7 @@ protected:
     int pt_x;
     int pt_y;
     SDL_Surface* buf;
-    int draw_clr;
+    unsigned draw_clr;
     bool transp;
     _TTF_Font* font;
     bool antialiastext;


### PR DESCRIPTION
Since - for some reason - OS X needs the blue color component to be shifted by 24 to the left, and `int` is 32 bits wide on OS X, using any color of which the blue component is greater than 127 results in shifting a `1` to the sign bit of an `int`, which invokes undefined behavior. This commit fixes that by declaring `draw_clr` as an `unsigned` integer.
